### PR TITLE
Installation Fixes

### DIFF
--- a/bones/__init__.py
+++ b/bones/__init__.py
@@ -8,7 +8,6 @@ import consensus
 import tools
 import tasks
 import packages
-import aws
 import illumina
 
 # handy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
+boto
 celery
+flywheel
 pysam
 plumbum
 


### PR DESCRIPTION
This fixes the requirements.txt file to include boto and flywheel requirements, and removes `import aws` from bones' `__init__.py` to make bones usable without AWS credentials
